### PR TITLE
Fix for error when passing variant to `addCommerceProductDetailView`

### DIFF
--- a/services/InstantAnalyticsService.php
+++ b/services/InstantAnalyticsService.php
@@ -171,7 +171,7 @@ class InstantAnalyticsService extends BaseApplicationComponent
 
     /**
      * Extract product data from a Craft Commerce Product or Variant
-     * @param Commerce_ProductModel or Commerce_VariantModel  $productVariant the Product or Variant
+     * @param Commerce_ProductModel|Commerce_VariantModel  $productVariant the Product or Variant
      * @return array the product data
      */
     public function getProductDataFromProduct($productVariant = null)
@@ -181,7 +181,10 @@ class InstantAnalyticsService extends BaseApplicationComponent
         {
             if (is_object($productVariant) && ($productVariant->getElementType() == "Commerce_Product" || is_a($productVariant, "Commerce\\Base\\Purchasable")))
             {
-                $productType = craft()->commerce_productTypes->getProductTypeById($productVariant->typeId);
+	            $productType = property_exists($productVariant, "typeId")
+		            ? craft()->commerce_productTypes->getProductTypeById($productVariant->typeId)
+		            : null;
+	            
                 if ($productType && $productType->hasVariants)
                 {
                     $productVariant = ArrayHelper::getFirstValue($productVariant->getVariants());
@@ -210,9 +213,9 @@ class InstantAnalyticsService extends BaseApplicationComponent
                     }
                     else
                     {
-                        $category = $productVariant->getType()['name'];
-                        $name = $productVariant->title;
-                        $variant = "";
+                        $category = $productVariant->product->getType()['name'];
+	                    $name = $productVariant->product->title;
+	                    $variant = $productVariant->title;
                     }
                 }
             }


### PR DESCRIPTION
Fix for `Craft\Commerce_VariantModel and its behaviors do not have a method or closure named "getType”.`