### PR TITLE
Fix GA parsing

### DIFF
--- a/services/InstantAnalyticsService.php
+++ b/services/InstantAnalyticsService.php
@@ -795,9 +795,8 @@ class InstantAnalyticsService extends BaseApplicationComponent
     {
         if (isset($_COOKIE['_ga']))
         {
-            list($version, $domainDepth, $cid1, $cid2) = preg_split('[\.]', $_COOKIE["_ga"], 4);
-            $contents = array('version' => $version, 'domainDepth' => $domainDepth, 'cid' => $cid1 . '.' . $cid2);
-            $cid = $contents['cid'];
+            $parts = preg_split('[\.]', $_COOKIE["_ga"], 4);
+            $cid = implode(array_slice($parts, 2), '.');
         }
         else
         {


### PR DESCRIPTION
Undefined index errors were thrown with a cookie like so:
```
Cookie: _ga=GA1.2.7f5e6360-aa06-4855-bb27-e64ff7885b6e;
```

The same bug is present in the craft 3 version.